### PR TITLE
PEP8 fixes

### DIFF
--- a/converge/settings.py
+++ b/converge/settings.py
@@ -101,7 +101,8 @@ def clone_git_repo(git_url, settings_dir, git_subdir=None):
 
     with tempfile.TemporaryDirectory() as temp_dir:
         clone_cmd = 'git clone %s %s' % (git_url, temp_dir)
-        src_dir = os.path.join(temp_dir, git_subdir) if git_subdir else temp_dir
+        src_dir = os.path.join(temp_dir, git_subdir) if git_subdir \
+            else temp_dir
         cp_cmd = 'cp -rvf %s/*_settings.py %s' % (src_dir, settings_dir)
 
         run_command(clone_cmd)
@@ -110,7 +111,8 @@ def clone_git_repo(git_url, settings_dir, git_subdir=None):
 
 def main():
     rc_config_default = {'APP_MODE': 'dev', 'SETTINGS_DIR': None,
-                         'GIT_SETTINGS_REPO': None, 'GIT_SETTINGS_SUBDIR': None}
+                         'GIT_SETTINGS_REPO': None,
+                         'GIT_SETTINGS_SUBDIR': None}
     rc_config = parse_rc(rc_config_default)
     settings_dir = rc_config['SETTINGS_DIR']
     git_url = rc_config['GIT_SETTINGS_REPO']

--- a/setup.py
+++ b/setup.py
@@ -17,4 +17,3 @@ setup(
     author_email='pythonic@gmail.com',
     license="http://www.opensource.org/licenses/mit-license.php",
     )
-

--- a/tests.py
+++ b/tests.py
@@ -80,7 +80,7 @@ def test_git_settings():
                 ]
     open('.convergerc', 'w').writelines(rc_lines)
     settings.reload()
-    assert settings.PROD == True
+    assert settings.PROD is True
 
 
 def teardown_module():


### PR DESCRIPTION
A few changes to conform to pep8.

**Before changes:**

leonardo@converge ◈ pycodestyle .
./setup.py:20:1: W391 blank line at end of file
./tests.py:83:26: E712 comparison to True should be 'if cond is True:' or 'if cond:'
./converge/settings.py:104:80: E501 line too long (80 > 79 characters)
./converge/settings.py:113:80: E501 line too long (80 > 79 characters)

**After changes:**

leonardo@converge ◈ pycodestyle .
leonardo@converge ◈ 

